### PR TITLE
为tmpzTreeMove_arrow，zTreeDragUL 设置z-index

### DIFF
--- a/css/zTreeStyle/zTreeStyle.css
+++ b/css/zTreeStyle/zTreeStyle.css
@@ -80,11 +80,11 @@ website:	http://code.google.com/p/jquerytree/
 
 ul.tmpTargetzTree {background-color:#FFE6B0; opacity:0.8; filter:alpha(opacity=80)}
 
-span.tmpzTreeMove_arrow {width:16px; height:16px; display: inline-block; padding:0; margin:2px 0 0 1px; border:0 none; position:absolute;
+span.tmpzTreeMove_arrow {z-index:10000; width:16px; height:16px; display: inline-block; padding:0; margin:2px 0 0 1px; border:0 none; position:absolute;
 	background-color:transparent; background-repeat:no-repeat; background-attachment: scroll;
 	background-position:-110px -80px; background-image:url("./img/zTreeStandard.png"); *background-image:url("./img/zTreeStandard.gif")}
 
-ul.ztree.zTreeDragUL {margin:0; padding:0; position:absolute; width:auto; height:auto;overflow:hidden; background-color:#cfcfcf; border:1px #00B83F dotted; opacity:0.8; filter:alpha(opacity=80)}
+ul.ztree.zTreeDragUL {z-index:10000; margin:0; padding:0; position:absolute; width:auto; height:auto;overflow:hidden; background-color:#cfcfcf; border:1px #00B83F dotted; opacity:0.8; filter:alpha(opacity=80)}
 .zTreeMask {z-index:10000; background-color:#cfcfcf; opacity:0.0; filter:alpha(opacity=0); position:absolute}
 
 /* level style*/


### PR DESCRIPTION
当Tree所在上层DOM的z-index > 0时不能正常显示拖拽时的箭头和DragUL
