### PR TITLE
Performance problem in zTree init with 1k nodes and exhide

### DIFF
--- a/js/jquery.ztree.exhide-3.5.js
+++ b/js/jquery.ztree.exhide-3.5.js
@@ -281,17 +281,21 @@
 //	Override method in core
 	var _dInitNode = data.initNode;
 	data.initNode = function(setting, level, node, parentNode, isFirstNode, isLastNode, openFlag) {
-		var tmpPNode = (parentNode) ? parentNode: data.getRoot(setting),
-			children = tmpPNode[setting.data.key.children];
-		data.tmpHideFirstNode = view.setFirstNodeForHide(setting, children);
-		data.tmpHideLastNode = view.setLastNodeForHide(setting, children);
-		view.setNodeLineIcos(setting, data.tmpHideFirstNode);
-		view.setNodeLineIcos(setting, data.tmpHideLastNode);
-		isFirstNode = (data.tmpHideFirstNode === node);
-		isLastNode = (data.tmpHideLastNode === node);
+		if (openFlag) {
+			var tmpPNode = (parentNode) ? parentNode: data.getRoot(setting),
+				children = tmpPNode[setting.data.key.children];
+			data.tmpHideFirstNode = view.setFirstNodeForHide(setting, children);
+			data.tmpHideLastNode = view.setLastNodeForHide(setting, children);
+			view.setNodeLineIcos(setting, data.tmpHideFirstNode);
+			view.setNodeLineIcos(setting, data.tmpHideLastNode);
+			isFirstNode = (data.tmpHideFirstNode === node);
+			isLastNode = (data.tmpHideLastNode === node);
+		}
 		if (_dInitNode) _dInitNode.apply(data, arguments);
-		if (isLastNode) {
-			view.clearOldLastNode(setting, node);
+		if (openFlag) {
+			if (isLastNode) {
+				view.clearOldLastNode(setting, node);
+			}
 		}
 	};
 


### PR DESCRIPTION
Hi,

Thank you for this awesome tree component :) It's one of the best in the web.

We are experiencing huge performance degradation when performing zTree init with ~1k nodes with many branches and exhide. After we tracked problem down, we found that in initialization phase, when zTree DOM is not yet ready, this function invokes `view.setNodeLineIcos(..)` for every branch/item (?) which causes jQuery calls to query DOM tree for the specific elements. The Firefox and Chrome are working quite fast and the problem may not be observed or it may not have such big impact, but on IE8 the browser is constantly displaying message about the "script is running too slow". In our case, when zTree with exhide in FF/Chrome needs ~4 seconds to initialize, on IE8 it takes more than ~40 seconds... Such huge lag completely kills even the best user experience. Proposed change is to fix it, but you may have other, better ideas, of how this can be fixed.

I tested this change in our environment and everything seems to be working fine, but still I'm not sure if it does not impact other scenarios, so I will need to leave the verification in your hands.

Take care! 
