### PR TITLE
update the method: updataNode

### DIFF
--- a/js/jquery.ztree.core.js
+++ b/js/jquery.ztree.core.js
@@ -1856,6 +1856,9 @@
 				updateNode : function(node, checkTypeFlag) {
 					if (!node) return;
 					var nObj = $$(node, setting);
+					// Since a collapsed node is not appended to the HTML dom until it is expanded, 
+					// it is necessary to append it first when updating a node which has not been expanded bofore.
+					if(!nObj.get(0)) view.appendParentULDom(setting,node); 
 					if (nObj.get(0) && tools.uCanDo(setting)) {
 						view.setNodeName(setting, node);
 						view.setNodeTarget(setting, node);


### PR DESCRIPTION
Since a collapsed node is not appended to the HTML dom until it is expanded, it is necessary to append it first when updating a node which has not been expanded bofore. For example,
1 init a ztree with other nodes collapsed and the radio button triggers the updating of some nodes
![2016-11-30_233603](https://cloud.githubusercontent.com/assets/13885442/20758868/2a1aca50-b756-11e6-94eb-1dbc14a05c8e.png)
2 however only the expanded nodes work
![2016-11-30_233637](https://cloud.githubusercontent.com/assets/13885442/20758884/348f506e-b756-11e6-95cc-7b15dcfbf8be.png)
3 because the other nodes have not been appended to the dom before
![2016-11-30_233740](https://cloud.githubusercontent.com/assets/13885442/20758892/39b761c6-b756-11e6-9f79-a4fdfa5af9ae.png)
