### PR TITLE
fix bug: can't drag tree node to other tree when has multi tree  if  set setting.drag.inner=false

### DIFF
--- a/js/jquery.ztree.all.js
+++ b/js/jquery.ztree.all.js
@@ -3134,7 +3134,7 @@
 						}
 					} else {
 						moveType = consts.move.TYPE_INNER;
-						if (tmpTarget && tools.apply(targetSetting.edit.drag.inner, [targetSetting.treeId, nodes, null], !!targetSetting.edit.drag.inner)) {
+						if (tmpTarget) {
 							tmpTarget.addClass(consts.node.TMPTARGET_TREE);
 						} else {
 							tmpTarget = null;

--- a/js/jquery.ztree.exedit.js
+++ b/js/jquery.ztree.exedit.js
@@ -592,7 +592,7 @@
 						}
 					} else {
 						moveType = consts.move.TYPE_INNER;
-						if (tmpTarget && tools.apply(targetSetting.edit.drag.inner, [targetSetting.treeId, nodes, null], !!targetSetting.edit.drag.inner)) {
+						if (tmpTarget) {
 							tmpTarget.addClass(consts.node.TMPTARGET_TREE);
 						} else {
 							tmpTarget = null;


### PR DESCRIPTION
fix bug: can't drag tree node to other tree when has multi tree if  set setting.drag.inner=false; demo_url: http://www.treejs.cn/v3/demo.php\#_308; 当设置 setting.drag.inner=false时, 无法将节点拖拽到其他树上