### PR TITLE
修复节点名为空时的处理方法

### DIFF
--- a/demo/cn/exedit/edit_fun.html
+++ b/demo/cn/exedit/edit_fun.html
@@ -33,6 +33,7 @@
 				beforeDrag: beforeDrag,
 				beforeRemove: beforeRemove,
 				beforeRename: beforeRename,
+				onRename: OnRename,
 				onRemove: onRemove
 			}
 		};
@@ -66,11 +67,14 @@
 		function beforeRename(treeId, treeNode, newName) {
 			if (newName.length == 0) {
 				alert("节点名称不能为空.");
-				var zTree = $.fn.zTree.getZTreeObj("treeDemo");
-				setTimeout(function(){zTree.editName(treeNode)}, 10);
-				return false;
 			}
 			return true;
+		}
+		function OnRename(event, treeId, treeNode){
+			if(treeNode.name.length == 0){
+				zTree = $.fn.zTree.getZTreeObj("treeDemo");
+				setTimeout(function(){zTree.editName(treeNode)}, 10);
+			}
 		}
 		function showLog(str) {
 			if (!log) log = $("#log");


### PR DESCRIPTION
当编辑节点名时，使其节点名为空后，此时若点击其它节点，将导致浏览器无限弹出警告窗口。
通过新增onRename事件方法，在该事件中使input重新获取焦点，可以修复该问题。