### PR TITLE
Dev

### DIFF
--- a/js/jquery.ztree.core.js
+++ b/js/jquery.ztree.core.js
@@ -1841,7 +1841,7 @@
                     }
                     view.asyncNode(this.setting, isRoot ? null : parentNode, !!isSilent, callback);
                 },
-                 refresh: function (extraSetting) { // 在refresh时根据需求更新setting，通过es6的Object.assign()函数此setting将与原来的setting对象合并。
+                 refresh: function (extraSetting) { // 在refresh时根据需求向refresh函数传入新的setting对象，通过es6的Object.assign()函数新的setting对象将与原来的setting对象合并，从而可在实例化之后通过操作节点时更改setting。
                     this.setting.treeObj.empty();
                     var root = data.getRoot(Object.assign(setting,extraSetting)),
                         nodes = root[setting.data.key.children]

--- a/js/jquery.ztree.core.js
+++ b/js/jquery.ztree.core.js
@@ -1841,9 +1841,9 @@
                     }
                     view.asyncNode(this.setting, isRoot ? null : parentNode, !!isSilent, callback);
                 },
-                 refresh: function (exitSetting) { // 在refresh时根据需求更新setting，此setting将与原来的setting对象合并。
+                 refresh: function (extraSetting) { // 在refresh时根据需求更新setting，此setting将与原来的setting对象合并。
                     this.setting.treeObj.empty();
-                    var root = data.getRoot(Object.assign(setting,exitSetting)),
+                    var root = data.getRoot(Object.assign(setting,extraSetting)),
                         nodes = root[setting.data.key.children]
                     data.initRoot(setting);
                     root[setting.data.key.children] = nodes

--- a/js/jquery.ztree.core.js
+++ b/js/jquery.ztree.core.js
@@ -1841,9 +1841,9 @@
                     }
                     view.asyncNode(this.setting, isRoot ? null : parentNode, !!isSilent, callback);
                 },
-                refresh: function () {
+                 refresh: function (exitSetting) { // 在refresh时根据需求更新setting，此setting将与原来的setting对象合并。
                     this.setting.treeObj.empty();
-                    var root = data.getRoot(setting),
+                    var root = data.getRoot(Object.assign(setting,exitSetting)),
                         nodes = root[setting.data.key.children]
                     data.initRoot(setting);
                     root[setting.data.key.children] = nodes

--- a/js/jquery.ztree.core.js
+++ b/js/jquery.ztree.core.js
@@ -1841,7 +1841,7 @@
                     }
                     view.asyncNode(this.setting, isRoot ? null : parentNode, !!isSilent, callback);
                 },
-                 refresh: function (extraSetting) { // 在refresh时根据需求更新setting，此setting将与原来的setting对象合并。
+                 refresh: function (extraSetting) { // 在refresh时根据需求更新setting，通过es6的Object.assign()函数此setting将与原来的setting对象合并。
                     this.setting.treeObj.empty();
                     var root = data.getRoot(Object.assign(setting,extraSetting)),
                         nodes = root[setting.data.key.children]


### PR DESCRIPTION
在使用的过程中碰到一个场景想在同一个ztree树下 在不同的时候 点击父节点时 让 beforeCollpase 分别返回true或者false。没有找到其它更好的方法。
所以我尝试更改refresh函数，向refresh 函数新加了一个参数。
在refresh时根据需求向refresh函数传入新的setting对象，通过es6的Object.assign()函数新的setting对象将与原来的setting对象合并，从而可在实例化之后通过操作节点时更改setting。
不知道此处更改是否会有其它影响，存在潜在的bug,还请释疑。