### PR TITLE
Update to Keyboard Navigation

### DIFF
--- a/demo/en/core/searchNodes.html
+++ b/demo/en/core/searchNodes.html
@@ -7,11 +7,48 @@
 	<link rel="stylesheet" href="../../../css/zTreeStyle/zTreeStyle.css" type="text/css">
 	<script type="text/javascript" src="../../../js/jquery-1.4.4.min.js"></script>
 	<script type="text/javascript" src="../../../js/jquery.ztree.core.js"></script>
+	<script src="https://use.fontawesome.com/952447aaab.js"></script>
 	<!--  <script type="text/javascript" src="../../../js/jquery.ztree.excheck.js"></script>
 	  <script type="text/javascript" src="../../../js/jquery.ztree.exedit.js"></script>-->
+	<style>
+		.ztree li > a.highlight_alt
+		{
+			color: #00A600 !important;
+			font-weight: bold;
+		}
+		.ztree li > a.highlight span.node_name:before,
+		.ztree li > a.highlight_hiddennodes span.node_name:before,
+		.ztree li > a.hiddennodes span.node_name:before 
+		{
+			font-family: FontAwesome;
+			color: green;
+			font-size: 14px;
+			margin-right: 4px;
+			position: absolute;
+			background-color: white;
+			margin-left: -9px;
+		}
+		.ztree li > a.highlight span.node_name:before
+		{
+			content: '\f058';
+		}
+		.ztree li > a.hiddennodes span.node_name:before 
+		{
+			content: '\f00e';
+		}
+		.ztree li > a.highlight.hiddennodes span.node_name:before
+		{
+			content: '\f058\f00e';
+		}
+	</style>
 	<SCRIPT type="text/javascript">
 		<!--
 		var setting = {
+			callback:
+			{
+				onCollapse: clickButton,
+				onExpand: clickButton
+			},
 			data: {
 				key: {
 					title: "t"
@@ -21,7 +58,8 @@
 				}
 			},
 			view: {
-				fontCss: getFontCss
+				fontCss: getFontCss,
+				nodeClasses: getNodeClasses
 			}
 		};
 
@@ -51,10 +89,16 @@
 				key.addClass("empty");
 			}
 		}
-		var lastValue = "", nodeList = [], fontCss = {};
+		var lastValue = "", nodeList = [], fontCss = {}, nodeClasses = [];
 		function clickRadio(e) {
 			lastValue = "";
 			searchNode(e);
+		}
+		function clickButton(e, treeId, treeNode)
+		{
+			if ( $("#styleNodesByCSS").attr('checked') ) return;
+			updateNodes(false, treeNode);
+			updateNodes(true, treeNode)
 		}
 		function searchNode(e) {
 			var zTree = $.fn.zTree.getZTreeObj("treeDemo");
@@ -75,8 +119,8 @@
 				}
 				if (lastValue === value) return;
 				lastValue = value;
-				if (value === "") return;
 				updateNodes(false);
+				if (value === "") return;
 
 				if ($("#getNodeByParam").attr("checked")) {
 					var node = zTree.getNodeByParam(keyType, value);
@@ -97,15 +141,57 @@
 			updateNodes(true);
 
 		}
-		function updateNodes(highlight) {
+		function updateNodes(highlight, node = null) {
 			var zTree = $.fn.zTree.getZTreeObj("treeDemo");
-			for( var i=0, l=nodeList.length; i<l; i++) {
+			var applyClasses = $("#styleNodesByClasses").attr('checked');
+			var expanded = node && node.open;
+
+			// If expanding a node then it MUST be a parent
+			// in which case it cannot be hiding matched nodes
+			if ( applyClasses && expanded )
+			{
+				node.hiddenNodes = false;
+				zTree.updateNode(node);
+			}
+
+			for( var i=0, l=nodeList.length; i<l; i++ )
+			{
 				nodeList[i].highlight = highlight;
+				nodeList[i].hiddenNodes = false;
+				if ( applyClasses && highlight )
+				{
+					// Make parent nodes of matched nodes show the 
+					// existence of hidden nodes if the parent is closed.
+					var node = nodeList[i];
+					while( true )
+					{
+						if ( ! node.parentTId ) break;
+						var parentNode = zTree.getNodeByTId( node.parentTId );
+						if ( parentNode.isParent && parentNode.open ) break;
+						parentNode.hiddenNodes = true;
+						zTree.updateNode( parentNode );
+						node = parentNode;
+					}
+				}
 				zTree.updateNode(nodeList[i]);
 			}
 		}
 		function getFontCss(treeId, treeNode) {
-			return (!!treeNode.highlight) ? {color:"#A60000", "font-weight":"bold"} : {color:"#333", "font-weight":"normal"};
+			return $("#styleNodesByCSS").attr('checked') 
+				? ((!!treeNode.highlight) ? {color:"#A60000", "font-weight":"bold"} : {color:"#333", "font-weight":"normal"})
+				: {color:"#333", "font-weight":"normal"};
+		}
+		function getNodeClasses(treeId, treeNode) {
+			var classes = $("#styleNodesByCSS").attr('checked') || ! ( !!treeNode.highlight || !!treeNode.hiddenNodes )
+				? {remove: ['highlight','highlight_alt','hiddennodes','highlight_hiddennodes']}
+				: ( !!treeNode.highlight
+					? ( (!!treeNode.hiddenNodes) 
+						? {add:['highlight','highlight_alt','hiddennodes']} 
+						: {add:['highlight','highlight_alt']} 
+					  )
+					: {add:['hiddennodes','highlight_alt']} 
+				  );
+			return classes;
 		}
 		function filter(node) {
 			return !node.isParent && node.isFirstNode;
@@ -126,6 +212,9 @@
 			$("#getNodesByParam").bind("change", clickRadio);
 			$("#getNodesByParamFuzzy").bind("change", clickRadio);
 			$("#getNodesByFilter").bind("change", clickRadio);
+			$("#styleNodesByCSS").bind("change", clickRadio);
+			$("#styleNodesByClasses").bind("change", clickRadio);
+			// $(".ztree li > span.button").bind("click", clickButton);
 		});
 		//-->
 	</SCRIPT>
@@ -152,6 +241,8 @@
 						<input type="radio" id="getNodesByParam" name="funType" class="radio" style="margin-left:36px;" /><span>getNodesByParam</span><br/>
 						<input type="radio" id="getNodesByParamFuzzy" name="funType" class="radio" style="margin-left:36px;" checked /><span>getNodesByParamFuzzy (only string)</span><br/>
 						<input type="radio" id="getNodesByFilter" name="funType" class="radio" style="margin-left:36px;" /><span>getNodesByFilter (see source: function filter)</span><br/>
+						<input type="radio" id="styleNodesByCSS" name="styleType" class="radio" style="margin-left:36px;" checked /><span>styleNodesByCSS (see source: function filter)</span><br/>
+						<input type="radio" id="styleNodesByClasses" name="styleType" class="radio" style="margin-left:36px;" /><span>styleNodesByClasses (see source: function filter)</span><br/>
 					</p>
 				</li>
 				</ul>

--- a/demo/js/keyboard_navigation.js
+++ b/demo/js/keyboard_navigation.js
@@ -14,6 +14,13 @@
 ( function ($) 
 {
 	/**
+	 * Dummy function to provide a placeholder for the destroy function
+	 */
+	$.fn.zTreeKeyboardNavigationDestroy = function()
+	{
+	}
+
+	/**
 	 * Creates a function that adds keyboard navigation:
 	 * Home: home key (keycode 36)				Goes to the first root element is visible
 	 * End: end key (keycode 35)				Goes to the last leaf node and will expand nodes and scroll the element into view
@@ -22,8 +29,11 @@
 	 * Up: up cursor key (keycode 37)			Goes to the prior visible node at the same level
 	 * Previous: left cursor key (keycode 38)	Goes to the prior visible node following the hierarchy
 	 * Toggle: space key (keycode 32)			Toggles the expand/collapse state of a parent node
+	 * @param {IxTreeObj} zTree
+	 * @param {string|JQuery<HTMLElement} element
+	 * @param {IJSON[]} selectedNodes
 	 */
-	$.fn.zTreeKeyboardNavigation = function(zTree, element)
+	$.fn.zTreeKeyboardNavigation = function(zTree, element, selectedNodes = null )
 		{
 			if (typeof element === 'string' || element instanceof String)
 			{
@@ -41,7 +51,18 @@
 				}
 			}
 
-			$(element).bind( 'keydown', function( e )
+			// Clear the previous event handler (there may be none)
+			$.fn.zTreeKeyboardNavigationDestroy();
+
+			/**
+			 * Make it possible to destroy (remove the event handlers)
+			 */
+			$.fn.zTreeKeyboardNavigationDestroy = function()
+			{
+				$(element).off( 'keydown' );
+			}
+
+			$(element).on( 'keydown', function( e )
 				{
 					var selectedNodes = zTree.getSelectedNodes();
 					var selectedNode = selectedNodes.length ? selectedNodes[0] : null;
@@ -248,8 +269,16 @@
 					focusSelectedNode();
 				} );
 
+			if ( selectedNodes && selectedNodes.length )
+			{
+				zTree.selectNode( selectedNodes[0] );
+				focusSelectedNode();
+			}
+			else
+			{
 			$(element).trigger({ type : 'keydown', which : 36, keyCode: 36 });
-			focusSelectedNode();
+			}
+
 		}
 
 } )(jQuery);

--- a/js/jquery.ztree.core.js
+++ b/js/jquery.ztree.core.js
@@ -67,6 +67,7 @@
         dblClickExpand: true,
         expandSpeed: "fast",
         fontCss: {},
+		nodeClasses: {},
         nameIsHTML: false,
         selectedMulti: true,
         showIcon: true,
@@ -1323,11 +1324,12 @@
         var title = data.nodeTitle(setting, node),
           url = view.makeNodeUrl(setting, node),
           fontcss = view.makeNodeFontCss(setting, node),
+		  nodeClasses = view.makeNodeClasses(setting, node),
           fontStyle = [];
         for (var f in fontcss) {
           fontStyle.push(f, ":", fontcss[f], ";");
         }
-        html.push("<a id='", node.tId, consts.id.A, "' class='", consts.className.LEVEL, node.level, "' treeNode", consts.id.A, " onclick=\"", (node.click || ''),
+        html.push("<a id='", node.tId, consts.id.A, "' class='", consts.className.LEVEL, node.level, ( 'add' in nodeClasses && nodeClasses.add ? ' ' + nodeClasses.add.join(' ') : '' ), "' treeNode", consts.id.A, " onclick=\"", (node.click || ''),
           "\" ", ((url != null && url.length > 0) ? "href='" + url + "'" : ""), " target='", view.makeNodeTarget(node), "' style='", fontStyle.join(''),
           "'");
         if (tools.apply(setting.view.showTitle, [setting.treeId, node], setting.view.showTitle) && title) {
@@ -1338,6 +1340,10 @@
       makeNodeFontCss: function (setting, node) {
         var fontCss = tools.apply(setting.view.fontCss, [setting.treeId, node], setting.view.fontCss);
         return (fontCss && ((typeof fontCss) != "function")) ? fontCss : {};
+      },
+      makeNodeClasses: function (setting, node) {
+        var classes = tools.apply(setting.view.nodeClasses, [setting.treeId, node], setting.view.nodeClasses);
+        return (classes && ((typeof classes) != "function")) ? classes : {add:[], remove:[]};
       },
       makeNodeIcoClass: function (setting, node) {
         var icoCss = ["ico"];
@@ -1639,6 +1645,16 @@
           fontCss = view.makeNodeFontCss(setting, treeNode);
         if (fontCss) {
           aObj.css(fontCss);
+        }
+      },
+      setNodeClasses: function (setting, treeNode) {
+        var aObj = $$(treeNode, consts.id.A, setting),
+          classes = view.makeNodeClasses(setting, treeNode);
+        if ('add' in classes && classes.add.length) {
+          aObj.addClass(classes.add.join(' '));
+        }
+        if ('remove' in classes && classes.remove.length) {
+          aObj.removeClass(classes.remove.join(' '));
         }
       },
       setNodeLineIcos: function (setting, node) {
@@ -1966,6 +1982,7 @@
             view.setNodeUrl(setting, node);
             view.setNodeLineIcos(setting, node);
             view.setNodeFontCss(setting, node);
+            view.setNodeClasses(setting, node);
           }
         }
       };


### PR DESCRIPTION
After creating the keyboard navigation code and testing it with the demo page provided I applied it to my application.  This revealed that I missed a use-case. 

In my real application the zTree shown to the user is created and destroyed as the user selects different contexts but the zTree container element is not removed.  This meant the keyboard navigation code should also be destroyed and the re-applied to the new zTree nodes.  However, the original keyboard navigation code did not do this and, as a result, multiple keyboard events would be fired for each keystroke.  The number of events being the number of times the zTree is re-created.

The code in this PR addresses this omission.