### PR TITLE
Add onclick handler only if it's not empty

### DIFF
--- a/js/jquery.ztree.core.js
+++ b/js/jquery.ztree.core.js
@@ -1343,8 +1343,9 @@
         }
         html.push("<a id='", node.tId, consts.id.A, "' class='", consts.className.LEVEL, node.level,
           nodeClasses.add ? ' ' + nodeClasses.add.join(' ') : '', 
-          "' treeNode", consts.id.A, " onclick=\"", (node.click || ''),
-          "\" ", ((url != null && url.length > 0) ? "href='" + url + "'" : ""), " target='", view.makeNodeTarget(node), "' style='", fontStyle.join(''),
+          "' treeNode", consts.id.A,
+          node.click ? " onclick=\"" + node.click + "\"" : "",
+          ((url != null && url.length > 0) ? " href='" + url + "'" : ""), " target='", view.makeNodeTarget(node), "' style='", fontStyle.join(''),
           "'");
         if (tools.apply(setting.view.showTitle, [setting.treeId, node], setting.view.showTitle) && title) {
           html.push("title='", title.replace(/'/g, "&#39;").replace(/</g, '&lt;').replace(/>/g, '&gt;'), "'");


### PR DESCRIPTION
This fix will remove warnings from console when inline javascript prohibited by Content-Security-Policy