### PR TITLE
fix: API addNodes 在异步时返回值数据异常Bug

### DIFF
--- a/js/jquery.ztree.core.js
+++ b/js/jquery.ztree.core.js
@@ -1044,7 +1044,7 @@
         view.makeUlHtml(setting, node, html, childHtml.join(''));
         nObj.append(html.join(''));
       },
-      asyncNode: function (setting, node, isSilent, callback) {
+      asyncNode: function (setting, node, isSilent, callback, isSync) {
         var i, l;
         var isParent = data.nodeIsParent(setting, node);
         if (node && !isParent) {
@@ -1085,6 +1085,7 @@
 
         var _tmpV = data.getRoot(setting)._ver;
         $.ajax({
+          async: !isSync,
           contentType: setting.async.contentType,
           cache: false,
           type: setting.async.type,
@@ -1342,7 +1343,7 @@
           fontStyle.push(f, ":", fontcss[f], ";");
         }
         html.push("<a id='", node.tId, consts.id.A, "' class='", consts.className.LEVEL, node.level,
-          nodeClasses.add ? ' ' + nodeClasses.add.join(' ') : '', 
+          nodeClasses.add ? ' ' + nodeClasses.add.join(' ') : '',
           "' treeNode", consts.id.A,
           node.click ? " onclick=\"" + node.click + "\"" : "",
           ((url != null && url.length > 0) ? " href='" + url + "'" : ""), " target='", view.makeNodeTarget(node), "' style='", fontStyle.join(''),
@@ -1806,7 +1807,7 @@
           }
 
           if (tools.canAsync(setting, parentNode)) {
-            view.asyncNode(setting, parentNode, isSilent, addCallback);
+            view.asyncNode(setting, parentNode, isSilent, addCallback, true);
           } else {
             addCallback();
           }


### PR DESCRIPTION
当zTree数据是异步加载的，在调用zTree.addNodes(parentNode, [index], newNodes, isSilent)方法时的返回值可能是addNodes()方法的newNodes入参，而非 zTree 最终添加的节点数据集合。